### PR TITLE
Added missing link to howto install btsync

### DIFF
--- a/how/Using-SYNC-to-get-the-Image.md
+++ b/how/Using-SYNC-to-get-the-Image.md
@@ -1,6 +1,8 @@
 #Jasper - Using Sync to get the Image for Jasper
 
-1. Install btsync, like here.
+On a Debian/Ubuntu style system:
+
+1. Install btsync, like [here](http://ubuntuhandbook.org/index.php/2016/02/howto-install-bittorrent-sync-from-its-official-repository/).
 2. Start it like described.
 3. Open your browser with http://127.0.0.1:8888/
 4. Fill out the resilio registration form.

--- a/how/Using-SYNC-to-get-the-Image.md
+++ b/how/Using-SYNC-to-get-the-Image.md
@@ -1,8 +1,8 @@
 #Jasper - Using Sync to get the Image for Jasper
 
-On a Debian/Ubuntu style system:
+On a Linux system:
 
-1. Install btsync, like [here](http://ubuntuhandbook.org/index.php/2016/02/howto-install-bittorrent-sync-from-its-official-repository/).
+1. Install btsync, like [here](https://help.getsync.com/hc/en-us/articles/206178924-Installing-Sync-package-on-Linux).
 2. Start it like described.
 3. Open your browser with http://127.0.0.1:8888/
 4. Fill out the resilio registration form.


### PR DESCRIPTION
- Added missing link to the howto for Debian based systems.
- Also added simple clarification to which system the guide aplies.